### PR TITLE
Implemented the new stat requirements for v0.5.4 release

### DIFF
--- a/KavitaStats/Controllers/StatsController.cs
+++ b/KavitaStats/Controllers/StatsController.cs
@@ -62,6 +62,16 @@ namespace KavitaStats.Controllers
                 existingRecord.NumberOfReadingLists = dto.NumberOfReadingLists;
                 existingRecord.TotalFiles = dto.TotalFiles;
                 existingRecord.OPDSEnabled = dto.OPDSEnabled;
+                existingRecord.TotalGenres = dto.TotalGenres;
+                existingRecord.TotalPeople = dto.TotalPeople;
+                existingRecord.StoreBookmarksAsWebP = dto.StoreBookmarksAsWebP;
+                existingRecord.UsersOnCardLayout = dto.UsersOnCardLayout;
+                existingRecord.UsersOnListLayout = dto.UsersOnListLayout;
+                existingRecord.MaxSeriesInALibrary = dto.MaxSeriesInALibrary;
+                existingRecord.MaxVolumesInASeries = dto.MaxVolumesInASeries;
+                existingRecord.MaxChaptersInASeries = dto.MaxChaptersInASeries;
+                existingRecord.UsingSeriesRelationships = dto.UsingSeriesRelationships;
+                
             }
             else
             {
@@ -82,6 +92,15 @@ namespace KavitaStats.Controllers
                     NumberOfReadingLists = dto.NumberOfReadingLists,
                     TotalFiles = dto.TotalFiles,
                     OPDSEnabled = dto.OPDSEnabled,
+                    TotalGenres = dto.TotalGenres,
+                    TotalPeople = dto.TotalPeople,
+                    StoreBookmarksAsWebP = dto.StoreBookmarksAsWebP,
+                    UsersOnCardLayout = dto.UsersOnCardLayout,
+                    UsersOnListLayout = dto.UsersOnListLayout,
+                    MaxSeriesInALibrary = dto.MaxSeriesInALibrary,
+                    MaxVolumesInASeries = dto.MaxVolumesInASeries,
+                    MaxChaptersInASeries = dto.MaxChaptersInASeries,
+                    UsingSeriesRelationships = dto.UsingSeriesRelationships,
                 });
             }
 

--- a/KavitaStats/DTOs/StatRecordDto.cs
+++ b/KavitaStats/DTOs/StatRecordDto.cs
@@ -11,6 +11,7 @@ namespace KavitaStats.DTOs
         /// Unique Id that represents a unique install
         /// </summary>
         public string InstallId { get; set; }
+        public string Os { get; set; }
         /// <summary>
         /// If the Kavita install is using Docker
         /// </summary>
@@ -24,58 +25,96 @@ namespace KavitaStats.DTOs
         /// </summary>
         public string KavitaVersion { get; set; }
         /// <summary>
-        /// Number of Cores on the Kavita Install
+        /// Number of Cores on the instance
         /// </summary>
         public int NumOfCores { get; set; }
-
         /// <summary>
-        /// If the user has any bookmarks on their install
-        /// </summary>
-        public bool HasBookmarks { get; set; }
-
-        /// <summary>
-        /// The number of libraries
+        /// The number of libraries on the instance
         /// </summary>
         public int NumberOfLibraries { get; set; }
-        
+        /// <summary>
+        /// Does any user have bookmarks
+        /// </summary>
+        public bool HasBookmarks { get; set; }
         /// <summary>
         /// The site theme the install is using
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public string ActiveSiteTheme { get; set; }
-        
         /// <summary>
         /// The reading mode the main user has as a preference
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public ReaderMode MangaReaderMode { get; set; }
-        
         /// <summary>
         /// Number of users on the install
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public int NumberOfUsers { get; set; }
-        
         /// <summary>
         /// Number of collections on the install
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public int NumberOfCollections { get; set; }
-        
         /// <summary>
         /// Number of reading lists on the install (Sum of all users)
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public int NumberOfReadingLists { get; set; }
-        
         /// <summary>
         /// Is OPDS enabled
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public bool OPDSEnabled { get; set; }
-        
         /// <summary>
         /// Total number of files in the instance
         /// </summary>
+        /// <remarks>Introduced in v0.5.2</remarks>
         public int TotalFiles { get; set; }
-
         /// <summary>
-        /// How many updates this row has had
+        /// Total number of Genres in the instance
         /// </summary>
-        public long UpdateCount { get; set; } = 0;
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int TotalGenres { get; set; }
+        /// <summary>
+        /// Total number of People in the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int TotalPeople { get; set; }
+        /// <summary>
+        /// Is this instance storing bookmarks as WebP
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public bool StoreBookmarksAsWebP { get; set; }
+        /// <summary>
+        /// Number of users on this instance using Card Layout
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int UsersOnCardLayout { get; set; }
+        /// <summary>
+        /// Number of users on this instance using List Layout
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int UsersOnListLayout { get; set; }
+        /// <summary>
+        /// Max number of Series for any library on the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int MaxSeriesInALibrary { get; set; }
+        /// <summary>
+        /// Max number of Volumes for any library on the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int MaxVolumesInASeries { get; set; }
+        /// <summary>
+        /// Max number of Chapters for any library on the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int MaxChaptersInASeries { get; set; }
+        /// <summary>
+        /// Does this instance have relationships setup between series
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public bool UsingSeriesRelationships { get; set; }
     }
 }

--- a/KavitaStats/Data/Migrations/20220627144418_StatsFor0_5_4.Designer.cs
+++ b/KavitaStats/Data/Migrations/20220627144418_StatsFor0_5_4.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using KavitaStats.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace KavitaStats.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20220627144418_StatsFor0_5_4")]
+    partial class StatsFor0_5_4
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.6");

--- a/KavitaStats/Data/Migrations/20220627144418_StatsFor0_5_4.cs
+++ b/KavitaStats/Data/Migrations/20220627144418_StatsFor0_5_4.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KavitaStats.Data.Migrations
+{
+    public partial class StatsFor0_5_4 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "MaxChaptersInASeries",
+                table: "StatRecord",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MaxSeriesInALibrary",
+                table: "StatRecord",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "MaxVolumesInASeries",
+                table: "StatRecord",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "StoreBookmarksAsWebP",
+                table: "StatRecord",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TotalGenres",
+                table: "StatRecord",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TotalPeople",
+                table: "StatRecord",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UsersOnCardLayout",
+                table: "StatRecord",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UsersOnListLayout",
+                table: "StatRecord",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "UsingSeriesRelationships",
+                table: "StatRecord",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaxChaptersInASeries",
+                table: "StatRecord");
+
+            migrationBuilder.DropColumn(
+                name: "MaxSeriesInALibrary",
+                table: "StatRecord");
+
+            migrationBuilder.DropColumn(
+                name: "MaxVolumesInASeries",
+                table: "StatRecord");
+
+            migrationBuilder.DropColumn(
+                name: "StoreBookmarksAsWebP",
+                table: "StatRecord");
+
+            migrationBuilder.DropColumn(
+                name: "TotalGenres",
+                table: "StatRecord");
+
+            migrationBuilder.DropColumn(
+                name: "TotalPeople",
+                table: "StatRecord");
+
+            migrationBuilder.DropColumn(
+                name: "UsersOnCardLayout",
+                table: "StatRecord");
+
+            migrationBuilder.DropColumn(
+                name: "UsersOnListLayout",
+                table: "StatRecord");
+
+            migrationBuilder.DropColumn(
+                name: "UsingSeriesRelationships",
+                table: "StatRecord");
+        }
+    }
+}

--- a/KavitaStats/Entities/StatRecord.cs
+++ b/KavitaStats/Entities/StatRecord.cs
@@ -81,6 +81,51 @@ namespace KavitaStats.Entities
         /// Total number of files in the instance
         /// </summary>
         public int TotalFiles { get; set; }
+        /// <summary>
+        /// Total number of Genres in the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int TotalGenres { get; set; }
+        /// <summary>
+        /// Total number of People in the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int TotalPeople { get; set; }
+        /// <summary>
+        /// Is this instance storing bookmarks as WebP
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public bool StoreBookmarksAsWebP { get; set; }
+        /// <summary>
+        /// Number of users on this instance using Card Layout
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int UsersOnCardLayout { get; set; }
+        /// <summary>
+        /// Number of users on this instance using List Layout
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int UsersOnListLayout { get; set; }
+        /// <summary>
+        /// Max number of Series for any library on the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int MaxSeriesInALibrary { get; set; }
+        /// <summary>
+        /// Max number of Volumes for any library on the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int MaxVolumesInASeries { get; set; }
+        /// <summary>
+        /// Max number of Chapters for any library on the instance
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public int MaxChaptersInASeries { get; set; }
+        /// <summary>
+        /// Does this instance have relationships setup between series
+        /// </summary>
+        /// <remarks>Introduced in v0.5.4</remarks>
+        public bool UsingSeriesRelationships { get; set; }
 
         /// <summary>
         /// How many updates this row has had


### PR DESCRIPTION
# Added
- Added: Added new stats to help see how many features are being used from v0.5.3 and to prepare for upcoming performance release (v0.5.5). In addition, some of the new functionality (virtual scrolling) have new stats to ensure we are seeing how it performs on the user base rather than just the beta testers. New fields: Total Genres, Total People, If storing bookmarks as WebP, Users on Cards layout, Users on List Layout, Max number of Series in a Library, Max Volumes in a Series, Max Chapters in a Series, and if any series relationships are present.